### PR TITLE
fix: Added missing plugin for jekyll-seo-tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,7 @@ theme: minima
 
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag
 # Theme-specific settings
 
 # If you want to link only specific pages in your header, use this and add the path to the pages


### PR DESCRIPTION
Added missing plugin  jekyll-seo-tag to fix error on project setup. 

Fixes #7 