### PR TITLE
docs: add link to live deployed site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ jekyll serve
 
 You can view the live version of the site at:
 
-[http://127.0.0.1:4000/](http://127.0.0.1:4000/)
+[https://deploy-preview-39--todayinhistory-nscc.netlify.app/](https://deploy-preview-39--todayinhistory-nscc.netlify.app/)

--- a/README.md
+++ b/README.md
@@ -97,3 +97,8 @@ Use the following commands to start the Jekyll server:
 jekyll serve
 ```
 
+## Live Deployed Site
+
+You can view the live version of the site at:
+
+[http://127.0.0.1:4000/](http://127.0.0.1:4000/)


### PR DESCRIPTION
closes #38 
This pull request updates the README file to include a link to the live deployed site of the project. The link is added under the "Installation" section to help users easily access the live version of the site.