### PR TITLE
docs: Added new run commands to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,13 @@ bundle install
 ```
 
 ## Start the Application
-Use one of the following commands to start the Jekyll server:
+Use the following commands to start the Jekyll server:
 
-**Recommended:**
+
 ```sh
-bundle exec jekyll serve
-```  
-**Alternatively:**
-```sh
-jekyll serve
+jekyll build  
+
+jekyll serve  --future 
 ```
 
 ## Mac Installation


### PR DESCRIPTION
The future flag is now needed to see all the pages when running the project. I updated the readme to include these commands. 
jekyll build  
jekyll serve  --future 